### PR TITLE
Replace Newtonsoft.Json with System.Text.Json for net6.0+

### DIFF
--- a/src/SparkplugNet/GlobalUsings.cs
+++ b/src/SparkplugNet/GlobalUsings.cs
@@ -15,7 +15,11 @@ global using MQTTnet.Formatter;
 global using MQTTnet.Internal;
 global using MQTTnet.Protocol;
 
+#if NET6_0_OR_GREATER
+global using System.Text.Json.Serialization;
+#else
 global using Newtonsoft.Json;
+#endif
 
 global using ProtoBuf;
 

--- a/src/SparkplugNet/SparkplugNet.csproj
+++ b/src/SparkplugNet/SparkplugNet.csproj
@@ -37,12 +37,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MQTTnet" Version="4.1.4.563" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="protobuf-net" Version="3.1.25" />
     <PackageReference Include="Serilog" Version="2.12.0" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+    <ItemGroup>
     <None Include="..\..\Icon.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>


### PR DESCRIPTION
@SeppPenner please consider this change request for your 2.0 version
I would consider removing the need for Newtonsoft.Json a breaking change
I've not removed the Newtonsoft.Json dependency  for netstandard2.0 or netstandard2.1, since 
Newtonsoft.Json was the default before .NET Core 3.1

I would like to use your Sparkplug  library, but I'd rather not take on a Newtonsoft.Json dependency in my .NET 6 project

The unit tests are passing with these changes.