### PR TITLE
Bug Fix #58 - SparkplugApplication Required Known Metrics 

### DIFF
--- a/src/SparkplugNet/VersionB/SparkplugApplication.cs
+++ b/src/SparkplugNet/VersionB/SparkplugApplication.cs
@@ -144,8 +144,6 @@ public class SparkplugApplication : SparkplugApplicationBase<VersionBData.Metric
         // If we have any not valid metric, throw an exception.
         var metricsWithoutSequenceMetric = payload.Metrics.Where(m => m.Name != Constants.SessionNumberMetricName);
 
-        this.KnownMetricsStorage.ValidateIncomingMetrics(metricsWithoutSequenceMetric);
-
         switch (topic.MessageType)
         {
             case SparkplugMessageType.NodeBirth:


### PR DESCRIPTION
Solve issue mention in https://github.com/SeppPenner/SparkplugNet/issues/58 
"The package internally validates incoming NBIRTH metrics with metrics saved in KnownMetricsStorage and does not fire the NodeBirthReceived and NodeDataReceived event if we give an empty metrics list to start the host application and later when the edge node publishes NBIRTH"