### PR TITLE
#101 : HostApplication Required Known Metrics

### DIFF
--- a/src/SparkplugNet/VersionB/SparkplugNode.cs
+++ b/src/SparkplugNet/VersionB/SparkplugNode.cs
@@ -114,12 +114,12 @@ public sealed class SparkplugNode : SparkplugNodeBase<Metric>
     {
         // Filter out session number metric.
         var sessionNumberMetric = payload.Metrics.FirstOrDefault(m => m.Name == Constants.SessionNumberMetricName);
-        var metricsWithoutSequenceMetric = payload.Metrics.Where(m => m.Name != Constants.SessionNumberMetricName);
-        var filteredMetrics = this.KnownMetricsStorage.FilterMetrics(metricsWithoutSequenceMetric, topic.MessageType).ToList();
+        var metrics = payload.Metrics.ToList();
+        // var filteredMetrics = this.KnownMetricsStorage.FilterMetrics(metricsWithoutSequenceMetric, topic.MessageType).ToList();
 
         if (sessionNumberMetric is not null)
         {
-            filteredMetrics.Add(sessionNumberMetric);
+            metrics.Add(sessionNumberMetric);
         }
 
         // Handle messages.
@@ -131,11 +131,11 @@ public sealed class SparkplugNode : SparkplugNodeBase<Metric>
                     throw new InvalidOperationException($"Topic {topic} is invalid!");
                 }
 
-                await this.FireDeviceCommandReceived(topic.DeviceIdentifier, filteredMetrics);
+                await this.FireDeviceCommandReceived(topic.DeviceIdentifier, metrics);
                 break;
 
             case SparkplugMessageType.NodeCommand:
-                await this.FireNodeCommandReceived(filteredMetrics);
+                await this.FireNodeCommandReceived(metrics);
                 break;
         }
     }

--- a/src/SparkplugNet/VersionB/SparkplugNode.cs
+++ b/src/SparkplugNet/VersionB/SparkplugNode.cs
@@ -114,7 +114,7 @@ public sealed class SparkplugNode : SparkplugNodeBase<Metric>
     {
         // Filter out session number metric.
         var sessionNumberMetric = payload.Metrics.FirstOrDefault(m => m.Name == Constants.SessionNumberMetricName);
-        var metrics = payload.Metrics.ToList();
+        var metrics = payload.Metrics.Where(m => m.Name != Constants.SessionNumberMetricName).ToList();
         // var filteredMetrics = this.KnownMetricsStorage.FilterMetrics(metricsWithoutSequenceMetric, topic.MessageType).ToList();
 
         if (sessionNumberMetric is not null)


### PR DESCRIPTION
Solve issue mentions in #101 and related ticket #58 

"Removed filter metrics from SparkplugApplicationa and SparkplugNode which is validating incoming metrics with KnownMetricsStorage and not invoking the NodeBirthReceived , NodeDataReceived and NodeCommandReceived events if we pass empty metrics to start the host application and publish NBIRTH/NDATA from edge node"
