### PR TITLE
Fix #117 : Timestamp required for all Sparkplug B Version 3 metrics.

### DIFF
--- a/src/SparkplugNet.Tests/Messages/SparkplugMessageGeneratorTestVersion30.cs
+++ b/src/SparkplugNet.Tests/Messages/SparkplugMessageGeneratorTestVersion30.cs
@@ -96,12 +96,13 @@ public sealed class SparkplugMessageGeneratorTestVersion30
     public void TestNodeBirthMessageNamespaceB()
     {
         var dateTime = DateTimeOffset.UtcNow;
+        var timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         var message = this.messageGenerator.GetSparkplugNodeBirthMessage(SparkplugNamespace.VersionB, "group1", "edge1", this.metricsB, 0, 1, dateTime);
         var payloadVersionB = PayloadHelper.Deserialize<VersionBProtoBufPayload>(message.Payload);
 
         Assert.AreEqual("spBv1.0/group1/NBIRTH/edge1", message.Topic);
         Assert.IsNotNull(payloadVersionB);
-        Assert.AreEqual((ulong)dateTime.ToUnixTimeMilliseconds(), payloadVersionB.Timestamp);
+        Assert.AreEqual(timestamp, payloadVersionB.Timestamp);
         Assert.AreEqual(2, payloadVersionB.Metrics.Count);
 
         Assert.AreEqual(this.metricsB.First().Name, payloadVersionB.Metrics.ElementAt(0).Name);
@@ -111,6 +112,13 @@ public sealed class SparkplugMessageGeneratorTestVersion30
         Assert.AreEqual(this.seqMetricB.Name, payloadVersionB.Metrics.ElementAt(1).Name);
         Assert.AreEqual(Convert.ToUInt64(this.seqMetricB.Value), payloadVersionB.Metrics.ElementAt(1).LongValue);
         Assert.AreEqual((uint?)this.seqMetricB.DataType, payloadVersionB.Metrics.ElementAt(1).DataType);
+
+        foreach (var metric in payloadVersionB.Metrics)
+        {
+            // [tck-id-payloads-name-birth-data-requirement]
+            // The timestamp MUST be included with every metric in all NBIRTH, DBIRTH, NDATA, and DDATA messages.*#
+            Assert.AreEqual(metric.Timestamp, timestamp);
+        }
     }
 
     /// <summary>

--- a/src/SparkplugNet.Tests/Payloads/SparkplugPayloadConverterTestVersionB.cs
+++ b/src/SparkplugNet.Tests/Payloads/SparkplugPayloadConverterTestVersionB.cs
@@ -1353,7 +1353,7 @@ public sealed class SparkplugPayloadConverterTestVersionB
                 IsTransient = true,
                 IsNull = false,
                 DataType = (uint?)VersionBProtoBuf.DataType.UInt32,
-                LongValue = 7
+                IntValue = 7
             },
             new()
             {

--- a/src/SparkplugNet/Core/Messages/SparkplugMessageGenerator.cs
+++ b/src/SparkplugNet/Core/Messages/SparkplugMessageGenerator.cs
@@ -665,19 +665,13 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
-        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
-        {
-            foreach (var metric in metrics)
-            {
-                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
-            }
-        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),
             Seq = (ulong)sequenceNumber,
             Timestamp = (ulong)dateTime.ToUnixTimeMilliseconds()
         };
+        EnsureSparkplugBMetricTimestamps(ref payload);
 
         var convertedPayload = VersionB.PayloadConverter.ConvertVersionBPayload(payload);
         var serialized = PayloadHelper.Serialize(convertedPayload);
@@ -756,19 +750,13 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
-        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
-        {
-            foreach (var metric in metrics)
-            {
-                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
-            }
-        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),
             Seq = (ulong)sequenceNumber,
             Timestamp = (ulong)dateTime.ToUnixTimeMilliseconds()
         };
+        EnsureSparkplugBMetricTimestamps(ref payload);
 
         var convertedPayload = VersionB.PayloadConverter.ConvertVersionBPayload(payload);
         var serialized = PayloadHelper.Serialize(convertedPayload);
@@ -998,19 +986,13 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
-        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
-        {
-            foreach (var metric in metrics)
-            {
-                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
-            }
-        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),
             Seq = (ulong)sequenceNumber,
             Timestamp = (ulong)dateTime.ToUnixTimeMilliseconds()
         };
+        EnsureSparkplugBMetricTimestamps(ref payload);
 
         var convertedPayload = VersionB.PayloadConverter.ConvertVersionBPayload(payload);
         var serialized = PayloadHelper.Serialize(convertedPayload);
@@ -1089,19 +1071,13 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
-        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
-        {
-            foreach (var metric in metrics)
-            {
-                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
-            }
-        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),
             Seq = (ulong)sequenceNumber,
             Timestamp = (ulong)dateTime.ToUnixTimeMilliseconds()
         };
+        EnsureSparkplugBMetricTimestamps(ref payload);
 
         var convertedPayload = VersionB.PayloadConverter.ConvertVersionBPayload(payload);
         var serialized = PayloadHelper.Serialize(convertedPayload);
@@ -1129,7 +1105,6 @@ internal sealed class SparkplugMessageGenerator
     /// <param name="metrics">The metrics.</param>
     /// <param name="dateTime">The date time.</param>
     /// <returns>A new NCMD <see cref="MqttApplicationMessage"/>.</returns>
-    
     private static MqttApplicationMessage GetSparkplugNodeCommandA(
         SparkplugNamespace nameSpace,
         string groupIdentifier,
@@ -1176,20 +1151,14 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
-        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
-        {
-            foreach (var metric in metrics)
-            {
-                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
-            }
-        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),
             Seq = (ulong)sequenceNumber,
             Timestamp = (ulong)dateTime.ToUnixTimeMilliseconds()
         };
-
+        EnsureSparkplugBMetricTimestamps(ref payload);
+        
         var convertedPayload = VersionB.PayloadConverter.ConvertVersionBPayload(payload);
         var serialized = PayloadHelper.Serialize(convertedPayload);
 
@@ -1265,19 +1234,13 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
-        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
-        {
-            foreach (var metric in metrics)
-            {
-                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
-            }
-        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),
             Seq = (ulong)sequenceNumber,
             Timestamp = (ulong)dateTime.ToUnixTimeMilliseconds()
         };
+        EnsureSparkplugBMetricTimestamps(ref payload);
 
         var convertedPayload = VersionB.PayloadConverter.ConvertVersionBPayload(payload);
         var serialized = PayloadHelper.Serialize(convertedPayload);
@@ -1293,5 +1256,22 @@ internal sealed class SparkplugMessageGenerator
             .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtMostOnce)
             .WithRetainFlag(false)
             .Build();
+    }
+    
+    /// <summary>
+    /// Ensures that all metrics will contain a Timestamp if Sparkplug protol version is Version 3.0
+    /// Message timestamp will be added to all metrics that does not already contain timestamps 
+    /// [tck-id-payloads-name-birth-data-requirement]
+    /// </summary>
+    /// <param name="payload">The payload to update</param>
+    private void EnsureSparkplugBMetricTimestamps(ref Payload payload)
+    {
+        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
+        {
+            foreach (var metric in payload.Metrics)
+            {
+                metric.Timestamp ??= payload.Timestamp;
+            }
+        }
     }
 }

--- a/src/SparkplugNet/Core/Messages/SparkplugMessageGenerator.cs
+++ b/src/SparkplugNet/Core/Messages/SparkplugMessageGenerator.cs
@@ -665,6 +665,13 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
+        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
+        {
+            foreach (var metric in metrics)
+            {
+                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
+            }
+        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),
@@ -749,6 +756,13 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
+        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
+        {
+            foreach (var metric in metrics)
+            {
+                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
+            }
+        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),
@@ -984,6 +998,13 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
+        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
+        {
+            foreach (var metric in metrics)
+            {
+                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
+            }
+        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),
@@ -1068,6 +1089,13 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
+        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
+        {
+            foreach (var metric in metrics)
+            {
+                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
+            }
+        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),
@@ -1101,6 +1129,7 @@ internal sealed class SparkplugMessageGenerator
     /// <param name="metrics">The metrics.</param>
     /// <param name="dateTime">The date time.</param>
     /// <returns>A new NCMD <see cref="MqttApplicationMessage"/>.</returns>
+    
     private static MqttApplicationMessage GetSparkplugNodeCommandA(
         SparkplugNamespace nameSpace,
         string groupIdentifier,
@@ -1139,7 +1168,7 @@ internal sealed class SparkplugMessageGenerator
     /// <param name="sequenceNumber">The sequence number.</param>
     /// <param name="dateTime">The date time.</param>
     /// <returns>A new NCMD <see cref="MqttApplicationMessage"/>.</returns>
-    private static MqttApplicationMessage GetSparkplugNodeCommandB(
+    private MqttApplicationMessage GetSparkplugNodeCommandB(
         SparkplugNamespace nameSpace,
         string groupIdentifier,
         string edgeNodeIdentifier,
@@ -1147,6 +1176,13 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
+        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
+        {
+            foreach (var metric in metrics)
+            {
+                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
+            }
+        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),
@@ -1220,7 +1256,7 @@ internal sealed class SparkplugMessageGenerator
     /// <param name="sequenceNumber">The sequence number.</param>
     /// <param name="dateTime">The date time.</param>
     /// <returns>A new DCMD <see cref="MqttApplicationMessage"/>.</returns>
-    private static MqttApplicationMessage GetSparkplugDeviceCommandB(
+    private MqttApplicationMessage GetSparkplugDeviceCommandB(
         SparkplugNamespace nameSpace,
         string groupIdentifier,
         string edgeNodeIdentifier,
@@ -1229,6 +1265,13 @@ internal sealed class SparkplugMessageGenerator
         int sequenceNumber,
         DateTimeOffset dateTime)
     {
+        if (this.specificationVersion == SparkplugSpecificationVersion.Version30)
+        {
+            foreach (var metric in metrics)
+            {
+                metric.Timestamp ??= (ulong)dateTime.ToUnixTimeMilliseconds();
+            }
+        }
         var payload = new Payload
         {
             Metrics = metrics.ToList(),


### PR DESCRIPTION
This PR is to address #117 and the requirement for all Sparkplug B Version 3.0.0 metrics to have a timestamp added. 

Requirement:
https://github.com/eclipse-sparkplug/sparkplug/blob/e45b61002a2a0cacb4f11fa4be88670435ccfcb0/specification/src/main/asciidoc/chapters/Sparkplug_6_Payloads.adoc?plain=1#L475C1-L476C97

Changes:
1. All Sparkplug B Version 3 metrics without timestamp will now get the message timestamp assigned.
2. added unit test for 1.
3. Fixed a type error in SparkplugPayloadConverterTestVersionB to ensure all test can now pass.