### PR TITLE
Upgraded MQTTnet and protobuf-ne

### DIFF
--- a/src/SparkplugNet.Examples/SparkplugNet.Examples.csproj
+++ b/src/SparkplugNet.Examples/SparkplugNet.Examples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SparkplugNet.Tests/GlobalUsings.cs
+++ b/src/SparkplugNet.Tests/GlobalUsings.cs
@@ -1,5 +1,6 @@
 #pragma warning disable IDE0065 // Die using-Anweisung wurde falsch platziert.
 global using System.Text.Json;
+global using System.Buffers;
 
 global using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/SparkplugNet.Tests/Messages/SparkplugMessageGeneratorTestVersion30.cs
+++ b/src/SparkplugNet.Tests/Messages/SparkplugMessageGeneratorTestVersion30.cs
@@ -40,7 +40,7 @@ public sealed class SparkplugMessageGeneratorTestVersion30
     public void TestStateMessageNamespaceBOnline()
     {
         var message = this.messageGenerator.GetSparkplugStateMessage(SparkplugNamespace.VersionB, "scada1", true);
-        var payloadVersionB = JsonSerializer.Deserialize<StateMessage>(message.Payload);
+        var payloadVersionB = JsonSerializer.Deserialize<StateMessage>(message.Payload.ToArray());
 
         Assert.AreEqual("spBv1.0/STATE/scada1", message.Topic);
         Assert.IsNotNull(payloadVersionB);
@@ -56,7 +56,7 @@ public sealed class SparkplugMessageGeneratorTestVersion30
     public void TestStateMessageNamespaceBOffline()
     {
         var message = this.messageGenerator.GetSparkplugStateMessage(SparkplugNamespace.VersionB, "scada1", false);
-        var payloadVersionB = JsonSerializer.Deserialize<StateMessage>(message.Payload);
+        var payloadVersionB = JsonSerializer.Deserialize<StateMessage>(message.Payload.ToArray());
 
         Assert.AreEqual("spBv1.0/STATE/scada1", message.Topic);
         Assert.IsNotNull(payloadVersionB);

--- a/src/SparkplugNet.Tests/SparkplugNet.Tests.csproj
+++ b/src/SparkplugNet.Tests/SparkplugNet.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SparkplugNet/Core/Application/SparkplugApplicationBase.cs
+++ b/src/SparkplugNet/Core/Application/SparkplugApplicationBase.cs
@@ -293,7 +293,7 @@ public abstract partial class SparkplugApplicationBase<T> : SparkplugBase<T> whe
 
             if (SparkplugMessageTopic.TryParse(topic, out var topicParsed))
             {
-                var data = args.ApplicationMessage.PayloadSegment.Array ?? [];
+                var data = args.ApplicationMessage.Payload.ToArray();
                 return this.OnMessageReceived(topicParsed!, data);
             }
             else if (topic.Contains(SparkplugMessageType.StateMessage.GetDescription()))
@@ -381,7 +381,7 @@ public abstract partial class SparkplugApplicationBase<T> : SparkplugBase<T> whe
                 builder.WithWillContentType(willMessage.ContentType);
                 builder.WithWillCorrelationData(willMessage.CorrelationData);
                 builder.WithWillDelayInterval(willMessage.MessageExpiryInterval);
-                builder.WithWillPayload(willMessage.PayloadSegment);
+                builder.WithWillPayload(willMessage.Payload.ToArray());
                 builder.WithWillPayloadFormatIndicator(willMessage.PayloadFormatIndicator);
                 builder.WithWillQualityOfServiceLevel(willMessage.QualityOfServiceLevel);
                 builder.WithWillResponseTopic(willMessage.ResponseTopic);

--- a/src/SparkplugNet/Core/Node/SparkplugNodeBase.cs
+++ b/src/SparkplugNet/Core/Node/SparkplugNodeBase.cs
@@ -234,17 +234,17 @@ public abstract partial class SparkplugNodeBase<T> : SparkplugBase<T> where T : 
 
         if (SparkplugMessageTopic.TryParse(topic, out var messageTopic))
         {
-            var data = args.ApplicationMessage.PayloadSegment.Array ?? [];
+            var data = args.ApplicationMessage.Payload.ToArray();
             await this.OnMessageReceived(messageTopic!, data);
         }
         else if (topic.Contains(SparkplugMessageType.StateMessage.GetDescription()))
         {
             // Handle the STATE message before anything else as they're UTF-8 encoded.
-            await this.FireStatusMessageReceived(Encoding.UTF8.GetString(args.ApplicationMessage.PayloadSegment));
+            await this.FireStatusMessageReceived(args.ApplicationMessage.ConvertPayloadToString());
         }
         else
         {
-            throw new InvalidOperationException($"Received message on unkown topic {topic}: {args.ApplicationMessage.PayloadSegment:X2}.");
+            throw new InvalidOperationException($"Received message on unkown topic {topic}: {args.ApplicationMessage.Payload.ToArray():X2}.");
         }
     }
 
@@ -318,7 +318,7 @@ public abstract partial class SparkplugNodeBase<T> : SparkplugBase<T> where T : 
         builder.WithWillContentType(willMessage.ContentType);
         builder.WithWillCorrelationData(willMessage.CorrelationData);
         builder.WithWillDelayInterval(willMessage.MessageExpiryInterval);
-        builder.WithWillPayload(willMessage.PayloadSegment);
+        builder.WithWillPayload(willMessage.Payload.ToArray());
         builder.WithWillPayloadFormatIndicator(willMessage.PayloadFormatIndicator);
         builder.WithWillQualityOfServiceLevel(willMessage.QualityOfServiceLevel);
         builder.WithWillResponseTopic(willMessage.ResponseTopic);

--- a/src/SparkplugNet/Core/PayloadHelper.cs
+++ b/src/SparkplugNet/Core/PayloadHelper.cs
@@ -50,6 +50,22 @@ internal static class PayloadHelper
         return Serializer.Deserialize<T>(stream);
     }
 
+    /// <summary>
+    /// Deserializes the data to a proto payload.
+    /// </summary>
+    /// <typeparam name="T">The type.</typeparam>
+    /// <param name="data">The data.</param>
+    /// <returns>The <see cref="T:T?"/> value as deserialized object.</returns>
+    internal static T? Deserialize<T>(ReadOnlySequence<byte> data) where T : class
+    {
+        if (data.IsEmpty)
+        {
+            return null;
+        }
+
+        return Serializer.Deserialize<T>(data);
+    }
+
     // Todo: Adjust to callback via action / Func?
     /// <summary>
     /// The write bytes delegate.

--- a/src/SparkplugNet/Core/SparkplugBase.cs
+++ b/src/SparkplugNet/Core/SparkplugBase.cs
@@ -65,7 +65,7 @@ public partial class SparkplugBase<T> : ISparkplugConnection where T : IMetric, 
             this.NameSpace = SparkplugNamespace.VersionB;
         }
 
-        this.client = new MqttFactory().CreateMqttClient();
+        this.client = new MqttClientFactory().CreateMqttClient();
         this.messageGenerator = new SparkplugMessageGenerator(specificationVersion);
     }
 

--- a/src/SparkplugNet/GlobalUsings.cs
+++ b/src/SparkplugNet/GlobalUsings.cs
@@ -1,4 +1,5 @@
 #pragma warning disable IDE0065 // Die using-Anweisung wurde falsch platziert.
+global using System.Buffers;
 global using System.Buffers.Binary;
 global using System.Collections.Concurrent;
 global using System.ComponentModel;
@@ -13,7 +14,6 @@ global using System.Xml.Serialization;
 global using Microsoft.Extensions.Logging;
 
 global using MQTTnet;
-global using MQTTnet.Client;
 global using MQTTnet.Formatter;
 global using MQTTnet.Internal;
 global using MQTTnet.Protocol;
@@ -34,7 +34,6 @@ global using SparkplugNet.VersionB.Data;
 
 global using VersionAData = SparkplugNet.VersionA.Data;
 global using VersionAProtoBuf = SparkplugNet.VersionA.ProtoBuf;
-global using VersionBData = SparkplugNet.VersionB.Data;
 global using VersionBProtoBuf = SparkplugNet.VersionB.ProtoBuf;
 
 global using VersionADataTypeEnum = SparkplugNet.VersionA.Data.DataType;

--- a/src/SparkplugNet/SparkplugNet.csproj
+++ b/src/SparkplugNet/SparkplugNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net10.0</TargetFrameworks>
         <AssemblyName>SparkplugNet</AssemblyName>
         <RootNamespace>SparkplugNet</RootNamespace>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -13,7 +13,7 @@
         <Description>SparkplugNet is a library to use the Sparkplug IIoT standard in .Net.</Description>
         <PackageTags>c# csharp sparkplug mqtt</PackageTags>
         <PackageProjectUrl>https://www.nuget.org/packages/SparkplugNet/</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/SeppPenner/SparkplugNet</RepositoryUrl>
+        <RepositoryUrl>https://github.com/heppth/SparkplugNet</RepositoryUrl>
         <PackageIcon>Icon.png</PackageIcon>
         <RepositoryType>Github</RepositoryType>
         <PackageReleaseNotes>Version 1.3.10.0 (2024-07-02): Fixed negative values conversion issues, fixes https://github.com/SeppPenner/SparkplugNet/issues/96.</PackageReleaseNotes>
@@ -28,6 +28,7 @@
         <NoWarn>NU1803,CS0618,CS0809,NU1901,NU1902</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NuGetAuditMode>all</NuGetAuditMode>
+        <Version>1.4.0-patched</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/SparkplugNet/SparkplugNet.csproj
+++ b/src/SparkplugNet/SparkplugNet.csproj
@@ -40,8 +40,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
-        <PackageReference Include="protobuf-net" Version="3.2.45" />
+        <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
+        <PackageReference Include="protobuf-net" Version="3.2.56" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Upgraded `MQTTnet` from version `4.3.7.1207` to `5.0.1.1416` and `protobuf-net` from version `3.2.45` to `3.2.56

MQTTnet 5.0 has been exist since early 2025 with a few breaking changes, which have been adjusted with this pull request.